### PR TITLE
Fix Broken Link to Document Template Example [scriptster]

### DIFF
--- a/_posts/2015-07-13-ruby-scripting.md
+++ b/_posts/2015-07-13-ruby-scripting.md
@@ -184,5 +184,5 @@ initial expectations, you'll have all the power of Ruby at your disposal.
 
 Can the template be improved or made even simpler? Leave a comment below or
 submit a pull request
-[here](https://github.com/pazdera/scriptster/blob/master/examples/template.rb).
+[here](https://github.com/pazdera/scriptster/blob/master/examples/documented-template.rb).
 


### PR DESCRIPTION
Fix broken link to document template example in scriptster blog post.